### PR TITLE
implement parsing for `UciResponse`

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,7 +6,7 @@
 
 use std::{fmt, str::FromStr, time::Duration};
 
-use crate::{parse_uci_command, UciParseError};
+use crate::{parse_uci_command, parse_uci_response, UciParseError};
 
 #[cfg(feature = "types")]
 use crate::UciMove;
@@ -684,6 +684,12 @@ pub enum UciResponse<T = String> {
 }
 
 impl UciResponse {
+    /// Attempt to parse `input` into a valid [`UciResponse`].
+    #[inline(always)]
+    pub fn new(input: &str) -> Result<Self, UciParseError> {
+        parse_uci_response(input)
+    }
+
     /// Convenience wrapper for creating a [`UciResponse::Info`] variant without needing to specify a generic parameter.
     #[must_use]
     #[inline(always)]
@@ -713,6 +719,15 @@ impl<T: fmt::Display> UciResponse<T> {
     pub fn info_string(s: T) -> Self {
         let info = UciInfo::new().string(s);
         Self::Info(Box::new(info))
+    }
+}
+
+impl FromStr for UciResponse {
+    type Err = UciParseError;
+    /// Alias for [`UciResponse::new`].
+    #[inline(always)]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,34 +9,54 @@ use std::{str::FromStr, time::Duration};
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_until},
-    character::complete::{anychar, digit1, multispace0, multispace1},
+    character::complete::{anychar, digit1, multispace0, multispace1, one_of},
     combinator::{cut, eof, map, map_res, opt, recognize, value, verify},
-    multi::{many0_count, many1_count, many_till},
-    sequence::{delimited, pair, preceded},
+    error::Error,
+    multi::{many0, many0_count, many1_count, many_till},
+    sequence::{delimited, pair, preceded, tuple},
     Err, IResult,
 };
 
-use crate::{UciCommand, UciParseError, UciSearchOptions};
+use crate::{
+    UciBound, UciCheckingStatus, UciCommand, UciInfo, UciOption, UciOptionType, UciParseError,
+    UciResponse, UciScore, UciScoreType, UciSearchOptions,
+};
 
 #[cfg(feature = "types")]
 use crate::{uci_move, UciMove};
-
-#[cfg(not(feature = "types"))]
-use nom::{character::complete::one_of, sequence::tuple};
 
 /// Top-level parser to convert a string into a [`UciCommand`].
 ///
 /// See also [`UciCommand::new`]
 pub(crate) fn parse_uci_command(input: &str) -> Result<UciCommand, UciParseError> {
-    #[cfg(feature = "err-on-unused-input")]
-    let mut parser =
-        nom::combinator::all_consuming(map(many_till(anychar, parse_command), |(_, cmd)| cmd));
+    parse_uci_line(input, parse_command)
+}
 
+/// Top-level parser to convert a string into a [`UciResponse`].
+///
+/// See also [`UciResponse::new`]
+pub(crate) fn parse_uci_response(input: &str) -> Result<UciResponse, UciParseError> {
+    parse_uci_line(input, parse_response)
+}
+
+fn parse_uci_line<T, F>(input: &str, f: F) -> Result<T, UciParseError>
+where
+    F: FnMut(&str) -> IResult<&str, T>,
+{
     // The `many_till(anychar)` parser consumes any unknown characters until a command is parsed.
-    #[cfg(not(feature = "err-on-unused-input"))]
-    let mut parser = map(many_till(anychar, parse_command), |(_, cmd)| cmd);
+    #[allow(unused_mut)]
+    let mut parser = map(many_till(anychar, f), |(_, cmd)| cmd);
 
-    parser(input).map(|(_rest, cmd)| cmd).map_err(|e| match e {
+    #[cfg(feature = "err-on-unused-input")]
+    let mut parser = nom::combinator::all_consuming(parser);
+
+    parser(input)
+        .map(|(_rest, cmd)| cmd)
+        .map_err(|e| create_error(e, input))
+}
+
+fn create_error(err: Err<Error<&str>>, input: &str) -> UciParseError {
+    match err {
         // A recoverable error means that the command was not recognized
         Err::Error(_) | Err::Incomplete(_) => UciParseError::UnrecognizedCommand {
             cmd: input.to_string(),
@@ -66,29 +86,30 @@ pub(crate) fn parse_uci_command(input: &str) -> Result<UciCommand, UciParseError
                 UciParseError::InvalidArgument { cmd, arg }
             }
         }
-    })
+    }
 }
 
-/// Parses a single-word [`UciCommand`] like `uci` or `isready`.
-fn single_command<'a>(
-    ident: &'static str,
-    cmd: UciCommand,
-) -> impl FnMut(&'a str) -> IResult<&'a str, UciCommand> {
+/// Parses a single-word command like `uci` or `isready`.
+fn single_command<'a, T>(ident: &'static str, cmd: T) -> impl FnMut(&'a str) -> IResult<&'a str, T>
+where
+    T: Clone,
+{
     value(cmd, term(ident))
 }
 
-/// Parses a multi-word [`UciCommand`] like `go` or `setoption`.
-fn multi_command<'a, F>(
+/// Parses a multi-word command like `go` or `setoption`.
+fn multi_command<'a, T, F>(
     ident: &'static str,
     parser: F,
-) -> impl FnMut(&'a str) -> IResult<&'a str, UciCommand>
+) -> impl FnMut(&'a str) -> IResult<&'a str, T>
 where
-    F: FnMut(&'a str) -> IResult<&'a str, UciCommand>,
+    T: Clone,
+    F: FnMut(&'a str) -> IResult<&'a str, T>,
 {
     preceded(term(ident), cut(parser))
 }
 
-/// Parses a single UCI command
+/// Parses a single [`UciCommand`]
 fn parse_command(input: &str) -> IResult<&str, UciCommand> {
     alt((
         single_command("uci", UciCommand::Uci),
@@ -222,6 +243,200 @@ fn parse_bench_args(input: &str) -> IResult<&str, UciCommand> {
     map(parse_search_options, UciCommand::Bench)(input)
 }
 
+/// Parses a single [`UciResponse`]
+fn parse_response(input: &str) -> IResult<&str, UciResponse> {
+    alt((
+        multi_command("id", parse_id_args),
+        single_command("uciok", UciResponse::UciOk),
+        single_command("readyok", UciResponse::ReadyOk),
+        multi_command("bestmove", parse_bestmove_args),
+        multi_command("copyprotection", parse_copyprotection_args),
+        multi_command("registration", parse_registration_args),
+        multi_command("info", parse_info_args),
+        multi_command("option", parse_option_args),
+    ))(input)
+}
+
+/// Parses arguments to the `id` response.
+fn parse_id_args(input: &str) -> IResult<&str, UciResponse> {
+    let name = rest_after("name");
+    let author = rest_after("author");
+
+    alt((
+        map(name, |name| UciResponse::Name(name.to_string())),
+        map(author, |author| UciResponse::Author(author.to_string())),
+    ))(input)
+}
+
+/// Parses arguments to the `bestmove` response.
+fn parse_bestmove_args(input: &str) -> IResult<&str, UciResponse> {
+    let bestmove = alt((value(None, term("(none)")), map(recognize_uci_move, Some)));
+    let ponder = opt(multi_command("ponder", recognize_uci_move));
+
+    map(pair(bestmove, ponder), |(bestmove, ponder)| {
+        UciResponse::BestMove {
+            bestmove: bestmove.map(str::to_string),
+            ponder: ponder.map(str::to_string),
+        }
+    })(input)
+}
+
+/// Parses arguments to the `copyprotection` response.
+fn parse_copyprotection_args(input: &str) -> IResult<&str, UciResponse> {
+    map(parse_uci_checking_status, UciResponse::CopyProtection)(input)
+}
+
+/// Parses arguments to the `registration` response.
+fn parse_registration_args(input: &str) -> IResult<&str, UciResponse> {
+    map(parse_uci_checking_status, UciResponse::Registration)(input)
+}
+
+/// Parses [`UciCheckingStatus`], which is used in both the `copyprotection` and `registration` responses
+fn parse_uci_checking_status(input: &str) -> IResult<&str, UciCheckingStatus> {
+    alt((
+        single_command("checking", UciCheckingStatus::Checking),
+        single_command("ok", UciCheckingStatus::Ok),
+        single_command("error", UciCheckingStatus::Error),
+    ))(input)
+}
+
+/// Parses arguments to the `info` response.
+fn parse_info_args(input: &str) -> IResult<&str, UciResponse> {
+    let mut info = UciInfo::default();
+
+    let (input, _) = many0_count(alt((
+        map(num_after("depth"), |x| info.depth = Some(x)),
+        map(num_after("seldepth"), |x| info.seldepth = Some(x)),
+        map(time_after("time"), |x| {
+            info.time = Some(x.as_millis().to_string())
+        }),
+        map(num_after("nodes"), |x| info.nodes = Some(x)),
+        map(recognize_moves_after("pv"), |x| {
+            info.pv = x.into_iter().map(str::to_string).collect()
+        }),
+        map(num_after("multipv"), |x| info.multipv = Some(x)),
+        map(multi_command("score", parse_score_args), |x| {
+            info.score = Some(x)
+        }),
+        map(multi_command("currmove", recognize_uci_move), |x| {
+            info.currmove = Some(x.to_string())
+        }),
+        map(num_after("currmovenumber"), |x| {
+            info.currmovenumber = Some(x)
+        }),
+        map(num_after("hashfull"), |x| info.hashfull = Some(x)),
+        map(num_after("nps"), |x| info.nps = Some(x)),
+        map(num_after("tbhits"), |x| info.tbhits = Some(x)),
+        map(num_after("sbhits"), |x| info.sbhits = Some(x)),
+        map(num_after("cpuload"), |x| info.cpuload = Some(x)),
+        map(rest_after("string"), |x| info.string = Some(x.to_string())),
+        map(recognize_moves_after("refutation"), |x| {
+            info.refutation = x.into_iter().map(str::to_string).collect()
+        }),
+        map(
+            multi_command("currline", pair(opt(parse_num::<String>), recognize_moves)),
+            |(cpunr, moves)| {
+                info.currline = cpunr
+                    .into_iter()
+                    .chain(moves.into_iter().map(str::to_string))
+                    .collect();
+            },
+        ),
+    )))(input)?;
+
+    Ok((input, UciResponse::Info(Box::new(info))))
+}
+
+/// Parses arguments to `score` inside an `info` response
+fn parse_score_args(input: &str) -> IResult<&str, UciScore> {
+    let score_type = alt((
+        value(UciScoreType::Centipawns, term("cp")),
+        value(UciScoreType::Mate, term("mate")),
+    ));
+    let bound = opt(alt((
+        value(UciBound::Lowerbound, term("lowerbound")),
+        value(UciBound::Upperbound, term("upperbound")),
+    )));
+
+    map(
+        tuple((score_type, parse_signed_num, bound)),
+        |(score_type, score, bound)| UciScore {
+            score,
+            score_type,
+            bound,
+        },
+    )(input)
+}
+
+/// Parses arguments to the `option` response.
+fn parse_option_args(input: &str) -> IResult<&str, UciResponse> {
+    let name = between("name", "type");
+    let opt_type = preceded(
+        term("type"),
+        alt((
+            multi_command("check", parse_option_check_args),
+            multi_command("spin", parse_option_spin_args),
+            multi_command("combo", parse_option_combo_args),
+            single_command("button", UciOptionType::Button),
+            multi_command("string", parse_option_string_args),
+        )),
+    );
+
+    map(pair(name, opt_type), |(name, opt_type)| {
+        UciResponse::Option(UciOption {
+            name: name.to_string(),
+            opt_type,
+        })
+    })(input)
+}
+
+fn default<'a, T, F>(parser: F) -> impl FnMut(&'a str) -> IResult<&'a str, T>
+where
+    F: FnMut(&'a str) -> IResult<&'a str, T>,
+{
+    preceded(term("default"), parser)
+}
+
+/// Parses arguments to an `option` response with type `check`.
+fn parse_option_check_args(input: &str) -> IResult<&str, UciOptionType> {
+    map(default(parse_bool), |default| UciOptionType::Check {
+        default,
+    })(input)
+}
+
+/// Parses arguments to an `option` response with type `spin`.
+fn parse_option_spin_args(input: &str) -> IResult<&str, UciOptionType> {
+    map(
+        tuple((
+            default(parse_signed_num),
+            preceded(term("min"), parse_signed_num),
+            preceded(term("max"), parse_signed_num),
+        )),
+        |(default, min, max)| UciOptionType::Spin { default, min, max },
+    )(input)
+}
+
+/// Parses arguments to an `option` response with type `combo`.
+fn parse_option_combo_args(input: &str) -> IResult<&str, UciOptionType> {
+    map(
+        pair(
+            between("default", "var"),
+            many0(map(between("var", "var"), str::to_string)),
+        ),
+        |(default, vars)| UciOptionType::Combo {
+            default: default.to_string(),
+            vars,
+        },
+    )(input)
+}
+
+/// Parses arguments to an `option` response with type `string`.
+fn parse_option_string_args(input: &str) -> IResult<&str, UciOptionType> {
+    map(default(rest_nonempty), |default| UciOptionType::String {
+        default: default.to_string(),
+    })(input)
+}
+
 /// A combinator that takes an identifier `ident` and produces a parser that
 /// parses ONLY `ident`, consuming any leading/trailing whitespace and failing if
 /// anything other than EOF or whitespace follows `ident`.
@@ -253,29 +468,34 @@ fn rest_after<'a>(ident: &'a str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a
     preceded(term(ident), map(rest_nonempty, str::trim))
 }
 
+/// Parses a non-empty list of moves after `ident` into `&str`s
+fn recognize_moves_after<'a>(
+    ident: &'a str,
+) -> impl FnMut(&'a str) -> IResult<&'a str, Vec<&'a str>> {
+    preceded(term(ident), cut(recognize_moves))
+}
+
 /// Parses a non-empty list of moves after `ident`
 #[cfg(not(feature = "types"))]
 fn moves_after<'a>(ident: &'a str) -> impl FnMut(&'a str) -> IResult<&'a str, Vec<&'a str>> {
-    preceded(
-        term(ident),
-        cut(nom::multi::many0(delimited(
-            multispace0,
-            recognize(uci_move),
-            multispace0,
-        ))),
-    )
+    recognize_moves_after(ident)
 }
 
+/// Parses a non-empty list of moves after `ident`
 #[cfg(feature = "types")]
 fn moves_after<'a>(ident: &'a str) -> impl FnMut(&'a str) -> IResult<&'a str, Vec<UciMove>> {
-    preceded(
-        term(ident),
-        cut(nom::multi::many1(delimited(
-            multispace0,
-            uci_move,
-            multispace0,
-        ))),
-    )
+    preceded(term(ident), cut(moves))
+}
+
+/// Parses a non-empty list of moves into `&str`s
+fn recognize_moves<'a>(input: &str) -> IResult<&str, Vec<&str>> {
+    nom::multi::many0(delimited(multispace0, recognize_uci_move, multispace0))(input)
+}
+
+/// Parses a non-empty list of moves
+#[cfg(feature = "types")]
+fn moves<'a>(input: &str) -> IResult<&str, Vec<UciMove>> {
+    nom::multi::many1(delimited(multispace0, uci_move, multispace0))(input)
 }
 
 /// Parses everything after `fen` as a FEN until either the keyword `moves` or the end of the line.
@@ -285,7 +505,7 @@ fn parse_fen(input: &str) -> IResult<&str, &str> {
     between("fen", "moves")(input)
 }
 
-/// Parses and maps a base-10 number
+/// Parses and maps a positive base-10 number
 ///
 /// Negative numbers are handled by the `clamp-negatives` crate feature.
 fn parse_num<T>(input: &str) -> IResult<&str, T>
@@ -314,6 +534,19 @@ where
     preceded(term(ident), parse_num)
 }
 
+/// Parses and maps a signed base-10 number
+fn parse_signed_num<T>(input: &str) -> IResult<&str, T>
+where
+    T: FromStr + Default + Clone,
+{
+    map_res(recognize(pair(opt(one_of("+-")), digit1)), str::parse)(input)
+}
+
+/// Parses a [`bool`]
+fn parse_bool(input: &str) -> IResult<&str, bool> {
+    alt((value(false, term("false")), value(true, term("true"))))(input)
+}
+
 /// Parses and maps a [`Duration`]
 fn parse_time(input: &str) -> IResult<&str, Duration> {
     map(parse_num, Duration::from_millis)(input)
@@ -324,14 +557,11 @@ fn time_after<'a>(ident: &'a str) -> impl FnMut(&'a str) -> IResult<&'a str, Dur
     preceded(term(ident), parse_time)
 }
 
-#[cfg(not(feature = "types"))]
-/// Parses a UCI move, which is in the format `<start square><end square>[promotion]`.
+/// Recognizes a UCI move.
 ///
-/// This can also parse a nullmove, which is the string `0000`.
-///
-/// If the feature `validate-promotion-moves` is enabled, this function will fail to
-/// parse "invalid" moves such as `e2e4q` or `b7b8p`.
-fn uci_move(input: &str) -> IResult<&str, &str> {
+/// This is the default parser with the `types` feature disabled, but it's also used
+/// in [`UciResponse`]'s [`FromStr`] implementation, see [#1](https://github.com/dannyhammer/uci-parser/issues/1#issuecomment-2585831960)
+fn recognize_uci_move(input: &str) -> IResult<&str, &str> {
     // [a-h]
     #[inline(always)]
     fn file(input: &str) -> IResult<&str, char> {
@@ -391,11 +621,19 @@ fn uci_move(input: &str) -> IResult<&str, &str> {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Debug;
+
+    use crate::UciOption;
+
     use super::*;
 
-    /// Creates a new command and asserts that it is `Ok`.
-    fn new_cmd(input: &str) -> UciCommand {
-        let cmd = UciCommand::new(input);
+    /// Parses using [`FromStr`] and asserts that the result is `Ok`.
+    fn new_from_str<T>(input: &str) -> T
+    where
+        T: FromStr + Debug,
+        T::Err: Debug,
+    {
+        let cmd = T::from_str(input);
         assert!(
             cmd.is_ok(),
             "Failed to parse {input:?}\nGot {:?}",
@@ -404,10 +642,34 @@ mod tests {
         cmd.unwrap()
     }
 
+    /// Creates a new command and asserts that it is `Ok`.
+    fn new_cmd(input: &str) -> UciCommand {
+        new_from_str(input)
+    }
+
+    /// Creates a new response and asserts that it is `Ok`.
+    fn new_response(input: &str) -> UciResponse {
+        new_from_str(input)
+    }
+
+    /// Parses using [`FromStr`] and asserts that the result is `Err`.
+    fn new_err_from_str<T>(input: &str)
+    where
+        T: FromStr + Debug,
+        T::Err: Debug,
+    {
+        let cmd = T::from_str(input);
+        assert!(cmd.is_err(), "Should error from {input:?}\nGot {cmd:?}");
+    }
+
     /// Creates a new command and asserts that it is `Err`.
     fn new_err(input: &str) {
-        let cmd = UciCommand::new(input);
-        assert!(cmd.is_err(), "Should error from {input:?}\nGot {cmd:?}");
+        new_err_from_str::<UciCommand>(input)
+    }
+
+    /// Creates a new response and asserts that it is `Err`.
+    fn new_response_err(input: &str) {
+        new_err_from_str::<UciResponse>(input)
     }
 
     /// Converts a list of UCI-notation move strings to a vector of [`UciMove`] structs.
@@ -451,6 +713,15 @@ mod tests {
 
         let cmd = new_cmd("    isready ");
         assert_eq!(cmd, UciCommand::IsReady);
+    }
+
+    #[test]
+    fn test_parse_single_responses() {
+        let cmd = new_response(" \t\n uciok ");
+        assert_eq!(cmd, UciResponse::UciOk);
+
+        let cmd = new_response("    readyok ");
+        assert_eq!(cmd, UciResponse::ReadyOk);
     }
 
     #[test]
@@ -741,6 +1012,171 @@ mod tests {
         new_err("  go   movestogo    ");
 
         new_err("  go   movestogo   mate ");
+    }
+
+    #[test]
+    fn test_parse_id() {
+        let res = new_response("id name toad 3.0.0");
+        assert_eq!(res, UciResponse::Name("toad 3.0.0".to_string()));
+
+        let res = new_response("id author Danny Hammer <hammerapi@gmail.com>");
+        assert_eq!(
+            res,
+            UciResponse::Author("Danny Hammer <hammerapi@gmail.com>".to_string())
+        );
+
+        new_response_err("idname nope");
+        new_response_err("id name");
+    }
+
+    #[test]
+    fn test_parse_bestmove() {
+        fn test_bestmove(input: &str, bestmove: Option<String>, ponder: Option<String>) {
+            let res = new_response(input);
+            assert_eq!(res, UciResponse::BestMove { bestmove, ponder })
+        }
+
+        test_bestmove("bestmove e2e4", Some("e2e4".to_string()), None);
+        test_bestmove("bestmove (none)", None, None);
+        test_bestmove(
+            "bestmove e2e4 ponder d2d4",
+            Some("e2e4".to_string()),
+            Some("d2d4".to_string()),
+        );
+        test_bestmove(
+            "bestmove (none) ponder d2d4",
+            None,
+            Some("d2d4".to_string()),
+        );
+
+        new_response_err("bestmove e2e4 ponder");
+        new_response_err("bestmove ponder d2d4");
+    }
+
+    #[test]
+    fn test_parse_copyprotection_registration() {
+        fn test_parse_uci_checking_status<F>(command: &str, mut constructor: F)
+        where
+            F: FnMut(UciCheckingStatus) -> UciResponse,
+        {
+            let res = new_response(&format!("{command} checking"));
+            assert_eq!(res, constructor(UciCheckingStatus::Checking));
+            let res = new_response(&format!("{command} ok"));
+            assert_eq!(res, constructor(UciCheckingStatus::Ok));
+            let res = new_response(&format!("{command} error"));
+            assert_eq!(res, constructor(UciCheckingStatus::Error));
+        }
+
+        test_parse_uci_checking_status("copyprotection", UciResponse::CopyProtection);
+        test_parse_uci_checking_status("registration", UciResponse::Registration);
+    }
+
+    #[test]
+    fn test_parse_info() {
+        let res = new_response("info currmove e2e4 currmovenumber 1");
+        assert_eq!(
+            res,
+            UciResponse::info(UciInfo::new().currmove("e2e4").currmovenumber(1))
+        );
+
+        let res = new_response("info depth 12 nodes 123456 nps 100000");
+        assert_eq!(
+            res,
+            UciResponse::info(UciInfo::new().depth(12).nodes(123456).nps(100000)),
+        );
+
+        let res = new_response(
+            "info depth 2 score cp 214 time 1242 nodes 2124 nps 34928 pv e2e4 e7e5 g1f3",
+        );
+        assert_eq!(
+            res,
+            UciResponse::info(
+                UciInfo::new()
+                    .depth(2)
+                    .score(UciScore::cp(214))
+                    .time(1242)
+                    .nodes(2124)
+                    .nps(34928)
+                    .pv(["e2e4", "e7e5", "g1f3"])
+            )
+        );
+
+        let res = new_response("info refutation d1h5 g6h5");
+        assert_eq!(
+            res,
+            UciResponse::info(UciInfo::new().refutation(["d1h5", "g6h5"])),
+        );
+
+        let res = new_response("info refutation d1h5");
+        assert_eq!(res, UciResponse::info(UciInfo::new().refutation(["d1h5"])));
+
+        let res = new_response("info depth 1 seldepth 0");
+        assert_eq!(res, UciResponse::info(UciInfo::new().depth(1).seldepth(0)));
+
+        let res = new_response("info score cp 13  depth 1 nodes 13 time 15 pv f1b5");
+        assert_eq!(
+            res,
+            UciResponse::info(
+                UciInfo::new()
+                    .score(UciScore::cp(13))
+                    .depth(1)
+                    .nodes(13)
+                    .time(15)
+                    .pv(["f1b5"])
+            )
+        );
+
+        let res = new_response("info string I see you");
+        assert_eq!(res, UciResponse::info_string("I see you".to_string()));
+    }
+
+    #[test]
+    fn test_parse_option() {
+        let res = new_response("option name Nullmove type check default true");
+        assert_eq!(res, UciResponse::Option(UciOption::check("Nullmove", true)));
+
+        let res = new_response("option name Selectivity type spin default 2 min 0 max 4");
+        assert_eq!(
+            res,
+            UciResponse::Option(UciOption::spin("Selectivity", 2, 0, 4))
+        );
+
+        let res = new_response(
+            "option name Style type combo default Normal var Solid var Normal var Risky",
+        );
+        assert_eq!(
+            res,
+            UciResponse::Option(UciOption::combo(
+                "Style",
+                "Normal",
+                ["Solid", "Normal", "Risky"]
+            ))
+        );
+
+        let res = new_response(r"option name NalimovPath type string default c:\");
+        assert_eq!(
+            res,
+            UciResponse::Option(UciOption::string("NalimovPath", r"c:\"))
+        );
+
+        let res = new_response("option name Clear Hash type button");
+        assert_eq!(res, UciResponse::Option(UciOption::button("Clear Hash")));
+
+        let res = new_response(
+            "option name Style type combo default Normal var Not Normal var Normal var Very Normal",
+        );
+        assert_eq!(
+            res,
+            UciResponse::Option(UciOption::combo(
+                "Style",
+                "Normal",
+                ["Not Normal", "Normal", "Very Normal"]
+            ))
+        );
+
+        new_response_err("option name type button");
+        new_response_err("option name Incomplete");
+        new_response_err("option name Missing Values type spin");
     }
 
     #[test]


### PR DESCRIPTION
With this, `UciResponse` implements `FromStr` and has `UciResponse::new` mirroring `UciCommand`.

Probably shouldn't be merged until #4 is fixed (see commit description).

The initial commit does not break the shape of `UciResponse`, but it might be worth to consider a breaking change to allow parsing into `UciMove` directly the same way that it works for `UciCommand`. Otherwise the [documentation for the `types` feature](https://github.com/dannyhammer/uci-parser/blob/4559d15e8b77988736e76a5aaa29cc2fc910795a/README.md?plain=1#L140) might be misleading.

Another consideration might be to refine the types inside `UciInfo`, which are currently all `String`s. For example, [`depth`](https://github.com/dannyhammer/uci-parser/blob/4559d15e8b77988736e76a5aaa29cc2fc910795a/src/messages.rs#L879) could be `Option<u32>`, which would be in line with the [`depth` field of `UciSearchOptions`](https://github.com/dannyhammer/uci-parser/blob/4559d15e8b77988736e76a5aaa29cc2fc910795a/src/messages.rs#L523). [`refutation`](https://github.com/dannyhammer/uci-parser/blob/4559d15e8b77988736e76a5aaa29cc2fc910795a/src/messages.rs#L1004) could be a struct with a separate `String` for the move being refuted and [`currline`](https://github.com/dannyhammer/uci-parser/blob/4559d15e8b77988736e76a5aaa29cc2fc910795a/src/messages.rs#L1019C9-L1019C17) a struct with `Option<u32>` for the cpu number.

Let me know if you want any of those (or other) changes.